### PR TITLE
Add subkey enumeration to page schema; implement API endpoints for fe…

### DIFF
--- a/PAGE_SUBKEY_GUIDE.md
+++ b/PAGE_SUBKEY_GUIDE.md
@@ -1,0 +1,103 @@
+# Page Subkey Feature Guide
+
+## Overview
+
+The page collection now includes a `subkey` field that allows for more granular categorization of pages. This is particularly useful for legal pages and other specific content types.
+
+## Available Subkeys
+
+The following subkeys are available:
+
+- `terms` - Terms and Conditions
+- `privacy` - Privacy Policy
+- `cookie` - Cookie Policy
+- `cancel` - Cancellation Policy
+- `returns` - Returns Policy
+- `accessibility` - Accessibility Statement
+- `impressum` - Legal Notice/Impressum
+
+## API Endpoints
+
+### 1. Find Page by Subkey
+
+```bash
+GET /api/pages/subkey/:subkey?locale=en
+```
+
+**Example:**
+
+```bash
+# Get privacy policy page
+curl -X GET "http://localhost:1337/api/pages/subkey/privacy?locale=en"
+
+# Get terms and conditions page
+curl -X GET "http://localhost:1337/api/pages/subkey/terms?locale=en"
+```
+
+### 2. Find Page by Category and Subkey
+
+```bash
+GET /api/pages/category/:category/subkey/:subkey?locale=en
+```
+
+**Example:**
+
+```bash
+# Get privacy policy page in legal category
+curl -X GET "http://localhost:1337/api/pages/category/legal/subkey/privacy?locale=en"
+
+# Get terms page in legal category
+curl -X GET "http://localhost:1337/api/pages/category/legal/subkey/terms?locale=en"
+```
+
+### 3. Find Pages by Category (existing)
+
+```bash
+GET /api/pages/category/:category?locale=en
+```
+
+**Example:**
+
+```bash
+# Get all legal pages
+curl -X GET "http://localhost:1337/api/pages/category/legal?locale=en"
+```
+
+## Usage Examples
+
+### Frontend Integration
+
+```javascript
+// Get privacy policy
+const privacyPage = await fetch("/api/pages/subkey/privacy?locale=en");
+
+// Get terms and conditions
+const termsPage = await fetch("/api/pages/subkey/terms?locale=en");
+
+// Get specific legal page
+const legalPrivacyPage = await fetch(
+  "/api/pages/category/legal/subkey/privacy?locale=en",
+);
+```
+
+### Common Use Cases
+
+1. **Legal Pages**: Use subkeys like `terms`, `privacy`, `cookie`, `impressum`
+2. **Policy Pages**: Use subkeys like `cancel`, `returns`, `accessibility`
+3. **Multi-language Support**: Combine with locale parameter for translations
+
+## Admin Panel Usage
+
+1. Go to **Content Manager** → **Page**
+2. Create or edit a page
+3. Select a **Category** (e.g., "legal")
+4. Select a **Subkey** (e.g., "privacy")
+5. Fill in the content and publish
+
+## Benefits
+
+- **Organized Content**: Better categorization of similar pages
+- **Easy Retrieval**: Direct access to specific page types
+- **Flexible Structure**: Can use subkey alone or with category
+- **SEO Friendly**: Clear structure for search engines
+- **Multi-language**: Supports all configured locales

--- a/src/api/page/content-types/page/schema.json
+++ b/src/api/page/content-types/page/schema.json
@@ -93,6 +93,24 @@
           "localized": false
         }
       }
+    },
+    "subkey": {
+      "type": "enumeration",
+      "enum": [
+        "terms",
+        "privacy",
+        "cookie",
+        "cancel",
+        "returns",
+        "accessibility",
+        "impressum",
+        "about"
+      ],
+      "pluginOptions": {
+        "i18n": {
+          "localized": false
+        }
+      }
     }
   }
 }

--- a/src/api/page/controllers/page.js
+++ b/src/api/page/controllers/page.js
@@ -73,6 +73,63 @@ module.exports = createCoreController("api::page.page", ({ strapi }) => ({
     }
   },
 
+  // Custom method to find page by subkey
+  async findBySubkey(ctx) {
+    const { subkey } = ctx.params;
+    const { locale = "en" } = ctx.query;
+
+    if (!subkey) {
+      return ctx.badRequest("Subkey is required");
+    }
+
+    try {
+      const page = await strapi.documents("api::page.page").findFirst({
+        filters: {
+          subkey,
+          isActive: true,
+        },
+        locale,
+      });
+
+      if (!page) {
+        return ctx.notFound("Page not found");
+      }
+
+      return { data: page };
+    } catch (error) {
+      ctx.badRequest("Failed to fetch page", { error: error.message });
+    }
+  },
+
+  // Custom method to find pages by category and subkey
+  async findByCategoryAndSubkey(ctx) {
+    const { category, subkey } = ctx.params;
+    const { locale = "en" } = ctx.query;
+
+    if (!category || !subkey) {
+      return ctx.badRequest("Both category and subkey are required");
+    }
+
+    try {
+      const page = await strapi.documents("api::page.page").findFirst({
+        filters: {
+          category,
+          subkey,
+          isActive: true,
+        },
+        locale,
+      });
+
+      if (!page) {
+        return ctx.notFound("Page not found");
+      }
+
+      return { data: page };
+    } catch (error) {
+      ctx.badRequest("Failed to fetch page", { error: error.message });
+    }
+  },
+
   // Extend the default create method
   async create(ctx) {
     // Auto-generate slug if not provided

--- a/src/api/page/routes/custom.js
+++ b/src/api/page/routes/custom.js
@@ -24,5 +24,23 @@ module.exports = {
         middlewares: [],
       },
     },
+    {
+      method: "GET",
+      path: "/pages/subkey/:subkey",
+      handler: "page.findBySubkey",
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
+    {
+      method: "GET",
+      path: "/pages/category/:category/subkey/:subkey",
+      handler: "page.findByCategoryAndSubkey",
+      config: {
+        policies: [],
+        middlewares: [],
+      },
+    },
   ],
 };


### PR DESCRIPTION
…tching pages by subkey and category/subkey

- Introduced a new `subkey` enumeration in the page schema to categorize pages.
- Added API endpoints to retrieve pages by `subkey` and by both `category` and `subkey`, enhancing content retrieval capabilities.
- Improved error handling for the new endpoints to ensure better user feedback.